### PR TITLE
Updated to be compatible with job types

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -330,7 +330,12 @@ local function isAuthorized(door)
 	if door.allAuthorized then return true end
 
 	if door.authorizedJobs then
-		if (door.authorizedJobs[PlayerData.job.name] or door.authorizedJobs[PlayerData.job.type]) and PlayerData.job.grade.level >= door.authorizedJobs[PlayerData.job.name] then
+		local j=PlayerData.job.name;
+		if(door.authorizedJobs[j] == nil) then
+			j=PlayerData.job.type;
+		end
+
+		if (door.authorizedJobs[j]) and (PlayerData.job.grade.level >= door.authorizedJobs[j]) then
 			return true
 		elseif type(door.authorizedJobs[1]) == 'string' then
 			for _, job in pairs(door.authorizedJobs) do -- Support for old format

--- a/client/main.lua
+++ b/client/main.lua
@@ -330,7 +330,7 @@ local function isAuthorized(door)
 	if door.allAuthorized then return true end
 
 	if door.authorizedJobs then
-		if door.authorizedJobs[PlayerData.job.name] and PlayerData.job.grade.level >= door.authorizedJobs[PlayerData.job.name] then
+		if (door.authorizedJobs[PlayerData.job.name] or door.authorizedJobs[PlayerData.job.type]) and PlayerData.job.grade.level >= door.authorizedJobs[PlayerData.job.name] then
 			return true
 		elseif type(door.authorizedJobs[1]) == 'string' then
 			for _, job in pairs(door.authorizedJobs) do -- Support for old format

--- a/server/main.lua
+++ b/server/main.lua
@@ -71,7 +71,12 @@ local function isAuthorized(Player, door, usedLockpick)
 	if (door.pickable or door.lockpick) and usedLockpick then return true end
 
 	if door.authorizedJobs then
-		if (door.authorizedJobs[PlayerData.job.name] or door.authorizedJobs[PlayerData.job.type]) and Player.PlayerData.job.grade.level >= door.authorizedJobs[Player.PlayerData.job.name] then
+		local j = Player.PlayerData.job.name;
+		if(door.authorizedJobs[j] == nil) then
+			j=Player.PlayerData.job.type;
+		end
+
+		if (door.authorizedJobs[j]) and (Player.PlayerData.job.grade.level >= door.authorizedJobs[j]) then
 			return true
 		elseif type(door.authorizedJobs[1]) == 'string' then
 			for _, job in pairs(door.authorizedJobs) do -- Support for old format

--- a/server/main.lua
+++ b/server/main.lua
@@ -71,7 +71,7 @@ local function isAuthorized(Player, door, usedLockpick)
 	if (door.pickable or door.lockpick) and usedLockpick then return true end
 
 	if door.authorizedJobs then
-		if door.authorizedJobs[Player.PlayerData.job.name] and Player.PlayerData.job.grade.level >= door.authorizedJobs[Player.PlayerData.job.name] then
+		if (door.authorizedJobs[PlayerData.job.name] or door.authorizedJobs[PlayerData.job.type]) and Player.PlayerData.job.grade.level >= door.authorizedJobs[Player.PlayerData.job.name] then
 			return true
 		elseif type(door.authorizedJobs[1]) == 'string' then
 			for _, job in pairs(door.authorizedJobs) do -- Support for old format


### PR DESCRIPTION
**Describe Pull request**
Updated the doorlock to check if the job name OR type are among the ones passed in the authorizedJobs, instead of using only job name. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
