### PR TITLE
🐛Fix: Incorrect event parameters

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -397,7 +397,7 @@ RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
 	PlayerData = val
 end)
 
-RegisterNetEvent('qb-doorlock:client:setState', function(serverId, doorID, state, src, enableAnimation, enableSounds)
+RegisterNetEvent('qb-doorlock:client:setState', function(serverId, doorID, state, src, enableSounds, enableAnimation)
 	if not Config.DoorList[doorID] then return end
 	if enableAnimation == nil then enableAnimation = true end
 	if enableSounds == nil then enableSounds = true end


### PR DESCRIPTION
**Describe Pull request**
This PR fixes the client event parameters for setting a doors state. The server code sends `enableSounds` as the 5th parameter and `enableAnimation` as the 6th parameter, but on the client code the event handlers parameters have `enableSounds` set to be the 6th parameter and `enableAnimation` to instead be the 5th parameter.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**
