### PR TITLE
Changed doortext to middle of door

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -85,7 +85,7 @@ local function setTextCoords(data)
     if data.fixText then
         return GetOffsetFromEntityInWorldCoords(data.object, dx / 2, 0, 0)
     else
-        return GetOffsetFromEntityInWorldCoords(data.object, -dx / 2, 0, 0)
+        return GetOffsetFromEntityInWorldCoords(data.object, dx / 2, 0, 0)
     end
 end
 

--- a/config.lua
+++ b/config.lua
@@ -126,7 +126,7 @@ Config.DoorList = {
 		pickable = true,
 		distance = 1.5
 	},
-	-- Fleeca Door opened with lockpick
+	-- Pink Cage Fleeca Door opened with lockpick
 	{
 		objName = 'v_ilev_gb_vaubar',
 		objCoords  = vec3(314.61, -285.82, 54.49),
@@ -136,7 +136,7 @@ Config.DoorList = {
 		pickable = true,
 		distance = 1.5
 	},
-	-- Fleeca Door opened with lockpick
+	-- legion Square Fleeca Door opened with lockpick
 	{
 		objName = 'v_ilev_gb_vaubar',
 		objCoords  = vec3(148.96, -1047.12, 29.7),


### PR DESCRIPTION
**Describe Pull request**
This changed on line 88 in the client/main.lua stating to change the text in the middle of the door instead of the corners of the door to make it unlikely to see.

**If your PR is to fix an issue mention that issue here:**
This was for BUG[#137] stating it was in corner of door and was in the red now in the green/middle of the door

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
